### PR TITLE
Remove needless dependencies

### DIFF
--- a/net-protocol.gemspec
+++ b/net-protocol.gemspec
@@ -30,7 +30,4 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-
-  spec.add_dependency "timeout"
-  spec.add_dependency "io-wait"
 end


### PR DESCRIPTION
These are default gems, so there is no need to explicitly depend on them, and depending on them is actually harmful: https://bugs.ruby-lang.org/issues/18567